### PR TITLE
when calling an invalid "language" - p.e. /dasf - $newDocumentLocale …

### DIFF
--- a/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
+++ b/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
@@ -214,7 +214,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
             $document = Document::getById(1);
         }
 
-        if (is_null($newDocumentLocale)) {
+        if (empty($newDocumentLocale)) {
             $newDocumentLocale = $document->getProperty('language');
         }
 


### PR DESCRIPTION
…gets an empty string, thus the check on is_null fails

Problem was detected because errorpage wasn't rendered but a 500 was thrown

resolves #16