### PR TITLE
remove php 7.1 tests, fix hardlink properties test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,61 +21,71 @@ env:
         - DACHCOM_TEST_SECTION=codeception
 matrix:
     include:
-        -   name: "PHPStan Static Analysis (Pimcore 5.7.x, PHP 7.2)"
+        -   name: "PHPStan Static Analysis (Pimcore 5.8.x, PHP 7.3)"
             sudo: required
-            php: 7.2
+            php: 7.3
             env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.2.0"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.3.0"
                 - DACHCOM_TEST_SECTION=phpstan
-        -   name: "PHP ECS (Pimcore 5.6.x, PHP 7.2)"
+        -   name: "PHP ECS (Pimcore 5.8.x, PHP 7.3)"
             sudo: required
-            php: 7.2
+            php: 7.3
             env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.1.0"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.3.0"
                 - DACHCOM_TEST_SECTION=ecs
-        -   name: "Codeception Tests (Pimcore 5.4.x, PHP 7.1)"
-            sudo: required
-            php: 7.1
-            env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.0.4"
         -   name: "Codeception Tests (Pimcore 5.4.x, PHP 7.2)"
             sudo: required
             php: 7.2
             env:
                 - PIMCORE_SKELETON_BRANCH="tags/v1.0.4"
-        -   name: "Codeception Tests (Pimcore 5.5.x, PHP 7.1)"
+        -   name: "Codeception Tests (Pimcore 5.4.x, PHP 7.3)"
             sudo: required
-            php: 7.1
+            php: 7.3
             env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.0.5"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.0.4"
         -   name: "Codeception Tests (Pimcore 5.5.x, PHP 7.2)"
             sudo: required
             php: 7.2
             env:
                 - PIMCORE_SKELETON_BRANCH="tags/v1.0.5"
-        -   name: "Codeception Tests (Pimcore 5.6.x, PHP 7.1)"
+        -   name: "Codeception Tests (Pimcore 5.5.x, PHP 7.3)"
             sudo: required
-            php: 7.1
+            php: 7.3
             env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.1.0"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.0.5"
         -   name: "Codeception Tests (Pimcore 5.6.x, PHP 7.2)"
             sudo: required
             php: 7.2
             env:
                 - PIMCORE_SKELETON_BRANCH="tags/v1.1.0"
-        -   name: "Codeception Tests (Pimcore 5.7.x, PHP 7.1)"
+        -   name: "Codeception Tests (Pimcore 5.6.x, PHP 7.3)"
             sudo: required
-            php: 7.1
+            php: 7.3
             env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.2.0"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.1.0"
         -   name: "Codeception Tests (Pimcore 5.7.x, PHP 7.2)"
             sudo: required
             php: 7.2
             env:
                 - PIMCORE_SKELETON_BRANCH="tags/v1.2.0"
+        -   name: "Codeception Tests (Pimcore 5.7.x, PHP 7.3)"
+            sudo: required
+            php: 7.3
+            env:
+                - PIMCORE_SKELETON_BRANCH="tags/v1.2.0"
+        -   name: "Codeception Tests (Pimcore 5.8.x, PHP 7.2)"
+            sudo: required
+            php: 7.2
+            env:
+                - PIMCORE_SKELETON_BRANCH="tags/v1.3.0"
+        -   name: "Codeception Tests (Pimcore 5.8.x, PHP 7.3)"
+            sudo: required
+            php: 7.3
+            env:
+                - PIMCORE_SKELETON_BRANCH="tags/v1.3.0"
     allow_failures:
         -   env:
-                - PIMCORE_SKELETON_BRANCH="tags/v1.1.0"
+                - PIMCORE_SKELETON_BRANCH="tags/v1.3.0"
                 - DACHCOM_TEST_SECTION=ecs
     fast_finish: true
 

--- a/tests/_support/Helper/PimcoreBackend.php
+++ b/tests/_support/Helper/PimcoreBackend.php
@@ -419,8 +419,6 @@ class PimcoreBackend extends Module
         $hardlink->setSourceId($source->getId());
         $hardlink->setPropertiesFromSource(true);
         $hardlink->setChildrenFromSource(true);
-        $hardlink->setProperty('navigation_title', 'text', $key);
-        $hardlink->setProperty('navigation_name', 'text', $key);
 
         if ($locale !== null) {
             $hardlink->setProperty('language', 'text', $locale, false, true);

--- a/tests/functional.default.country/InternalLinksCest.php
+++ b/tests/functional.default.country/InternalLinksCest.php
@@ -15,8 +15,8 @@ class InternalLinksCest
         $documentSub1 = $I->haveASubPageDocument($document1, 'sub-page-1');
         $documentSubSub1 = $I->haveASubPageDocument($documentSub1, 'sub-sub-page-1');
 
-        $link1 = $I->haveASubLink($document1, $documentSubSub1, 'sub-link-1');
-        $hardlink1 = $I->haveAHardLink($document1, 'en-us', 'en_US');
+        $I->haveASubLink($document1, $documentSubSub1, 'sub-link-1');
+        $I->haveAHardLink($document1, 'en-us', 'en_US');
 
         $I->amOnPageWithLocaleAndCountry('/en', 'en-US', 'us');
         $I->seeLink('sub-link-1', '/en/sub-page-1/sub-sub-page-1');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

- Remove PHP 7.1 from Test-Matrix
- Add PHP 7.3 to Test-Matrix
- Add Pimcore 5.8 to Test-Matrix
- Fix wrong hard-link property allocation
