### PR TITLE
Localized error document when main domain of a site has www. subdomain

### DIFF
--- a/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
+++ b/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
@@ -135,7 +135,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
         $zoneDomains = $this->zoneManager->getCurrentZoneDomains(true);
         $exception = $event->getException();
 
-        $host = $event->getRequest()->getHost();
+        $host = preg_replace('/^www./', '', $event->getRequest()->getHost());
 
         // 1. get default system error page ($defaultErrorPath)
         $defaultErrorPath = Config::getSystemConfig()->documents->error_pages->default;
@@ -169,7 +169,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
             $validElements = array_keys(array_filter(
                 $zoneDomains,
                 function ($v) use ($host, $nearestDocumentLocale) {
-                    return $v['host'] === $host && $v['locale'] === $nearestDocumentLocale;
+                    return $v['realHost'] === $host && $v['locale'] === $nearestDocumentLocale;
                 }
             ));
 
@@ -196,7 +196,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
                     $validSourceElements = array_keys(array_filter(
                         $zoneDomains,
                         function ($v) use ($host, $nearestSourceDocumentLocale) {
-                            return $v['host'] === $host && $v['locale'] === $nearestSourceDocumentLocale;
+                            return $v['realHost'] === $host && $v['locale'] === $nearestSourceDocumentLocale;
                         }
                     ));
 

--- a/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
+++ b/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
@@ -169,7 +169,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
             $validElements = array_keys(array_filter(
                 $zoneDomains,
                 function ($v) use ($host, $nearestDocumentLocale) {
-                    return $v['realHost'] === $host && $v['locale'] === $nearestDocumentLocale;
+                    return $v['host'] === $host && $v['locale'] === $nearestDocumentLocale;
                 }
             ));
 
@@ -196,7 +196,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
                     $validSourceElements = array_keys(array_filter(
                         $zoneDomains,
                         function ($v) use ($host, $nearestSourceDocumentLocale) {
-                            return $v['realHost'] === $host && $v['locale'] === $nearestSourceDocumentLocale;
+                            return $v['host'] === $host && $v['locale'] === $nearestSourceDocumentLocale;
                         }
                     ));
 

--- a/tests/_etc/config/bundle/symfony/config_zone_hosts.yml
+++ b/tests/_etc/config/bundle/symfony/config_zone_hosts.yml
@@ -1,0 +1,19 @@
+pimcore:
+    documents:
+        error_pages:
+            default: /test-domain8-test/en/error
+
+i18n:
+    mode: language
+    locale_adapter: system
+    default_locale: 'en'
+    translations: ~
+    zones:
+        zone1:
+            id: 1
+            config:
+                mode: language
+                locale_adapter: system
+                translations: ~
+            domains:
+                - 'www.test-domain8.test'

--- a/tests/_support/Helper/PimcoreBackend.php
+++ b/tests/_support/Helper/PimcoreBackend.php
@@ -213,12 +213,14 @@ class PimcoreBackend extends Module
      *
      * @param string $siteKey
      * @param null   $locale
+     * @param bool   $add3w
+     * @param array  $additionalDomains
      *
      * @return Site
      */
-    public function haveASite($siteKey, $locale = null)
+    public function haveASite($siteKey, $locale = null, $add3w = false, $additionalDomains = [])
     {
-        $site = $this->generateSiteDocument($siteKey, $locale);
+        $site = $this->generateSiteDocument($siteKey, $locale, $add3w, $additionalDomains);
 
         try {
             $site->save();
@@ -264,7 +266,7 @@ class PimcoreBackend extends Module
      * @param string $key
      * @param string $locale
      *
-     * @return Page
+     * @return Hardlink
      */
     public function haveAHardlinkForSite(Site $site, Page $document, $key = 'hardlink-test', $locale = null)
     {
@@ -516,10 +518,12 @@ class PimcoreBackend extends Module
      *
      * @param string $domain
      * @param string $locale
+     * @param bool   $add3w
+     * @param array  $additionalDomains
      *
      * @return Site
      */
-    protected function generateSiteDocument($domain, $locale = null)
+    protected function generateSiteDocument($domain, $locale = null, $add3w = false, $additionalDomains = [])
     {
         $document = TestHelper::createEmptyDocumentPage($domain, false);
         $document->setProperty('navigation_title', 'text', $domain);
@@ -543,7 +547,11 @@ class PimcoreBackend extends Module
 
         $site = new Site();
         $site->setRootId((int) $document->getId());
-        $site->setMainDomain($domain);
+        $site->setMainDomain(($add3w ? 'www.' : '') . $domain);
+
+        if (count($additionalDomains) > 0) {
+            $site->setDomains($additionalDomains);
+        }
 
         return $site;
     }

--- a/tests/_support/Helper/PimcoreCore.php
+++ b/tests/_support/Helper/PimcoreCore.php
@@ -288,12 +288,17 @@ class PimcoreCore extends PimcoreCoreModule
     {
         $internalDomains = [
             '/test-domain1.test/',
+            '/test-domain1.test/',
+            '/test-domain1.test/',
             '/test-domain2.test/',
             '/test-domain3.test/',
             '/test-domain4.test/',
             '/test-domain5.test/',
             '/test-domain6.test/',
             '/test-domain7.test/',
+            '/test-domain7.test/',
+            '/test-domain8.test/',
+            '/www.test-domain8.test/',
         ];
 
         return array_unique($internalDomains);

--- a/tests/functional.zone.hosts.suite.dist.yml
+++ b/tests/functional.zone.hosts.suite.dist.yml
@@ -1,0 +1,14 @@
+actor: FunctionalTester
+error_level: 'getenv("PIMCORE_PHP_ERROR_REPORTING")'
+modules:
+    enabled:
+        - \DachcomBundle\Test\Helper\PimcoreCore:
+                connect_db: true
+                rebootable_client: true
+                configuration_file: 'config_zone_hosts.yml'
+        - \DachcomBundle\Test\Helper\PimcoreBundleCore:
+                run_installer: true
+        - \DachcomBundle\Test\Helper\Browser\PhpBrowser:
+                depends: \DachcomBundle\Test\Helper\PimcoreCore
+        - \DachcomBundle\Test\Helper\PimcoreBackend
+        - \DachcomBundle\Test\Helper\PimcoreUser

--- a/tests/functional.zone.hosts/ZoneHostCest.php
+++ b/tests/functional.zone.hosts/ZoneHostCest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DachcomBundle\Test\FunctionalZoneHosts;
+
+use DachcomBundle\Test\FunctionalTester;
+
+class ZoneHostCest
+{
+    /**
+     * @param FunctionalTester $I
+     */
+    public function testZoneWithAdditionalDomains(FunctionalTester $I)
+    {
+        $site1 = $I->haveASite('test-domain8.test', null, true, ['test-domain8.test']);
+
+        $document1 = $I->haveAPageDocumentForSite($site1, 'en', 'en');
+        $document2 = $I->haveASubPageDocument($document1, 'error', 'en');
+        $document3 = $I->haveAPageDocumentForSite($site1, 'de', 'de');
+        $document4 = $I->haveASubPageDocument($document3, 'error', 'de');
+
+        $I->amOnPageWithLocale('http://www.test-domain8.test/en/this-is-not-real', 'en');
+        $I->seeCurrentUrlEquals('/en/this-is-not-real');
+        $I->seeCurrentHostEquals('www.test-domain8.test');
+        $I->see($document2->getId(), '#page-id');
+
+        $I->amOnPageWithLocale('http://test-domain8.test/en/this-is-not-real', 'en');
+        $I->seeCurrentUrlEquals('/en/this-is-not-real');
+        $I->seeCurrentHostEquals('test-domain8.test');
+        $I->see($document2->getId(), '#page-id');
+
+        $I->amOnPageWithLocale('http://www.test-domain8.test/de/nicht-existent', 'de');
+        $I->seeCurrentUrlEquals('/de/nicht-existent');
+        $I->seeCurrentHostEquals('www.test-domain8.test');
+        $I->see($document4->getId(), '#page-id');
+
+        $I->amOnPageWithLocale('http://test-domain8.test/de/nicht-existent', 'de');
+        $I->seeCurrentUrlEquals('/de/nicht-existent');
+        $I->seeCurrentHostEquals('test-domain8.test');
+        $I->see($document4->getId(), '#page-id');
+    }
+}

--- a/tests/functional.zone.hosts/_bootstrap.php
+++ b/tests/functional.zone.hosts/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Steps to reproduce:
1. Create a site document named `example.org` with main domain `www.example.org` and additional domain `example.org` (and activated `Redirect additional domains to main domain` - do not know if this is important for this issue)
1. Create document `/example.org/de/404` with german language
2. Configure system default error document to be `/example.org/de/404`
3. Create document `/example.org/en/404` with english language
4. Call https://www.example.org/en/non-existing-page -> Default error page will be shown although there is a localized one.

The reason for that is that in https://github.com/dachcom-digital/pimcore-i18n/blob/adfb71c537b702516c0c5bd2788d43e1a528b2df/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php#L169-L174 the `realHost` of the zone domain gets used for comparison. `realHost` and `host` of the zone domain get set in https://github.com/dachcom-digital/pimcore-i18n/blob/adfb71c537b702516c0c5bd2788d43e1a528b2df/src/I18nBundle/Manager/ZoneManager.php#L453-L454
`$realHost` gets calculated by `getDomainHost()`:
https://github.com/dachcom-digital/pimcore-i18n/blob/adfb71c537b702516c0c5bd2788d43e1a528b2df/src/I18nBundle/Manager/ZoneManager.php#L551-L558
There the prepending `www.` gets removed. And for this reason above's comparison of the request host with `realHost` is `false`.

This PR changes the comparison to use `host` (which is the main domain name of the site). I do not know exactly if this is correct (especially if this would work when the checkbox to redirect additional site domains to the main domain is not set). 
Another way I can imagine is to set `$stripWWW` parameter of the `getDomainHost()` call to `false` - but have not tried that.