### PR TITLE
Use root language if Accept-Language locale does not exist as Pimcore language

### DIFF
--- a/src/I18nBundle/Helper/UserHelper.php
+++ b/src/I18nBundle/Helper/UserHelper.php
@@ -55,6 +55,12 @@ class UserHelper
             }
         }
 
+        foreach ($acceptLanguages as $acceptLanguage) {
+            if (in_array(substr($acceptLanguage, 0, 2), $pimcoreLanguages, true)) {
+                $guessedLanguages[] = $acceptLanguage;
+            }
+        }
+
         return $guessedLanguages;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master for features / 2.4 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | Resolves #62

When the browser only sends language-dialects and in Pimcore only the root language does exist the geo redirection did not work.
Example:
Browser sends `Accept-Language: de-de` (and not `de`)
Pimcore only has language `de`
In this case redirect did not work.

I added an additional loop to ensure that those generated root languages which are actually not present in the `Accept-Language` header are appended after the languages of the header. This way the original languages always have higher priority than those generated fallbacks