### PR TITLE
Update ZoneManager.php

### DIFF
--- a/src/I18nBundle/Manager/ZoneManager.php
+++ b/src/I18nBundle/Manager/ZoneManager.php
@@ -488,7 +488,7 @@ class ZoneManager
             'countryIso'       => $docCountryIso,
             'languageIso'      => $docRealLanguageIso,
             'hrefLang'         => $hrefLang,
-            'localeUrlMapping' => null,
+            'localeUrlMapping' => (!empty($docLocale)) ? $docLocale : null,
             'url'              => $domainUrl,
             'homeUrl'          => $domainUrl,
             'domainUrl'        => $domainUrl,


### PR DESCRIPTION
To set the localeUrlMapping for a root page

| Q             | A
| ------------- | ---
| Branch?       | dev-master for features / 2.4 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

When only a root page is given the localeUrlMapping is not set so the static routes are not working fine.
