### PR TITLE
Properly overriding Pimcore ResponseExceptionListener and multisite e…

### DIFF
--- a/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
+++ b/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
@@ -101,8 +101,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
         $headers = [];
 
         $exception = $event->getThrowable();
-
-        if ($event->getThrowable() instanceof HttpExceptionInterface) {
+        if ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
             $headers = $exception->getHeaders();
         }

--- a/src/I18nBundle/Resources/config/services/event.yml
+++ b/src/I18nBundle/Resources/config/services/event.yml
@@ -46,8 +46,9 @@ services:
             - { name: kernel.event_subscriber }
 
     # override pimcore not found exception handling
-    I18nBundle\EventListener\Frontend\ResponseExceptionListener:
+    Pimcore\Bundle\CoreBundle\EventListener\ResponseExceptionListener:
+        class: I18nBundle\EventListener\Frontend\ResponseExceptionListener
         calls:
-            - [setLogger, ['@logger']]
+            - [ setLogger, [ '@logger' ] ]
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
…rror page now takes precendece over system set error page

| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Fixed multisite 404 page handling. Now the site specific error page has priority over the system setting. Also properly overriding the pimcore ResponseExceptionListener
