### PR TITLE
add editmode response on language = empty-string

### DIFF
--- a/src/I18nBundle/EventListener/I18nStartupListener.php
+++ b/src/I18nBundle/EventListener/I18nStartupListener.php
@@ -85,7 +85,7 @@ class I18nStartupListener implements EventSubscriberInterface
             return;
         }
 
-        if ($document->getProperty('language') === null) {
+        if (!$document->getProperty('language')) {
             $this->buildEditModeResponse($event);
         }
     }


### PR DESCRIPTION
If the document was already saved with a language property and you remove the language later, it will not be null but an empty string