### PR TITLE
Respect Fallback Translation and Parameters 

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -39,13 +39,11 @@ jobs:
         strategy:
             matrix:
                 php: [ 8.0 ]
-                symfony: [ ^5.3 ]
-                pimcore: [ ~10.1.0, ~10.2.0 ]
+                symfony: [ ^5.4 ]
+                pimcore: [ ~10.5.0 ]
                 include:
-                    -   pimcore: ~10.1.0
-                        template_tag: v10.1.0
-                    -   pimcore: ~10.2.0
-                        template_tag: v10.1.4
+                    -   pimcore: ~10.5.0
+                        template_tag: v10.2.0
         steps:
             -   uses: actions/checkout@v2
                 with:

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -38,11 +38,11 @@ jobs:
         strategy:
             matrix:
                 php: [ 8.0 ]
-                symfony: [ ^5.3 ]
-                pimcore: [ ~10.1.0 ]
+                symfony: [ ^5.4 ]
+                pimcore: [ ~10.5.0 ]
                 include:
-                    -   pimcore: ~10.1.0
-                        template_tag: v10.1.0
+                    -   pimcore: ~10.5.0
+                        template_tag: v10.2.0
         steps:
             -   uses: actions/checkout@v2
                 with:

--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -38,11 +38,11 @@ jobs:
         strategy:
             matrix:
                 php: [ 8.0 ]
-                symfony: [ ^5.3 ]
-                pimcore: [ ~10.1.0 ]
+                symfony: [ ^5.4 ]
+                pimcore: [ ~10.5.0 ]
                 include:
-                    -   pimcore: ~10.1.0
-                        template_tag: v10.1.0
+                    -   pimcore: ~10.5.0
+                        template_tag: v10.2.0
         steps:
             -   uses: actions/checkout@v2
                 with:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 4.1.3
+- [BUGFIX] Zone Settings: Use fallback for translations [#114](https://github.com/dachcom-digital/pimcore-i18n/issues/114)
+- [BUGFIX] Allow parameters for translation config [#115](https://github.com/dachcom-digital/pimcore-i18n/issues/115)
 ## 4.1.2
 - [BUGFIX] Fix alternate links being pushed as web links [@alexej-d](https://github.com/dachcom-digital/pimcore-i18n/issues/97)
 - [BUGFIX] Fix strict locale property check [@GALCF](https://github.com/dachcom-digital/pimcore-i18n/pull/103)

--- a/src/I18nBundle/Builder/ZoneBuilder.php
+++ b/src/I18nBundle/Builder/ZoneBuilder.php
@@ -78,13 +78,15 @@ class ZoneBuilder
             ));
         }
 
+        $translations = array_merge($this->configuration->getConfig('translations'), $zoneDefinition['translations']);
+
         return new Zone(
             $currentZoneId,
             $currentZoneName,
             $zoneDefinition['default_locale'],
             $zoneDefinition['locale_adapter'],
             $zoneDefinition['mode'],
-            $zoneDefinition['translations'],
+            $translations,
             $currentZoneDomains
         );
     }

--- a/src/I18nBundle/DependencyInjection/I18nExtension.php
+++ b/src/I18nBundle/DependencyInjection/I18nExtension.php
@@ -15,6 +15,11 @@ class I18nExtension extends Extension implements PrependExtensionInterface
     {
         $configs = $container->getExtensionConfig($this->getAlias());
 
+        // first, we need to resolve parameters
+        // => allow placeholders in translation blocks for example
+        $resolvingBag = $container->getParameterBag();
+        $configs = $resolvingBag->resolveValue($configs);
+
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #114, #115 

This PR fixes:
- Always respect global translation blocks
- Allow to use parameters in configuration:

```yaml
i18n:
    translations: '%i18n_translations%'
```
