### PR TITLE
assert correct locale in static/symfony route, see #104

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 ## 4.1.3
 - [BUGFIX] Zone Settings: Use fallback for translations [#114](https://github.com/dachcom-digital/pimcore-i18n/issues/114)
 - [BUGFIX] Allow parameters for translation config [#115](https://github.com/dachcom-digital/pimcore-i18n/issues/115)
+- [BUGFIX] Assert correct locale in static/symfony route [#104](https://github.com/dachcom-digital/pimcore-i18n/issues/104)
 ## 4.1.2
 - [BUGFIX] Fix alternate links being pushed as web links [@alexej-d](https://github.com/dachcom-digital/pimcore-i18n/issues/97)
 - [BUGFIX] Fix strict locale property check [@GALCF](https://github.com/dachcom-digital/pimcore-i18n/pull/103)

--- a/docs/1_I18n.md
+++ b/docs/1_I18n.md
@@ -98,7 +98,8 @@ pimcore:
 ```
 
 ## Symfony Routes
-I18n also supports (localized) symfony routes. You need to pass the `_i18n` default flag (can be an array or just a boolean flag).
+I18n also supports (localized) symfony routes. 
+You need to pass the `_i18n` default flag (can be an array or just a boolean flag).
 
 ### Localized Symfony Routes
 ```yaml
@@ -108,9 +109,9 @@ my_symfony_route:
         fr: /fr/i18n/symfony-default-ruteee
         de_CH: /de-ch/i18n/symfony-default-route-guetzli
         en: /en/i18n/symfony-default-route
+    controller: App\Controller\DefaultController::symfonyRouteAction
     defaults:
         _i18n: true
-        _controller: App\Controller\DefaultController::symfonyRouteAction
 ```
 
 ### I18n Localized Symfony Routes
@@ -127,11 +128,11 @@ i18n:
               
 my_symfony_route:
     path: /{_locale}/i18n/{matching_route_key}
+    controller: App\Controller\DefaultController::symfonyRouteAction
     defaults:
         _i18n:
             translation_keys:
                 matching_route_key: mySymfonyRouteKey
-        _controller: App\Controller\DefaultController::symfonyRouteAction
     requirements:
         matching_route_key: '(%i18n.route.translations.mySymfonyRouteKey%)' ## returns (meine-symfony-route|my-symfony-route)
 ```

--- a/docs/92_SymfonyRoutes.md
+++ b/docs/92_SymfonyRoutes.md
@@ -1,7 +1,8 @@
 # Symfony Routes
 
 ### Routing
-First you need to create a valid route. Read more about the symfony route definitions [here](./1_I18n.md#symfony-routes).
+First you need to create a valid route. 
+Read more about the symfony route definitions [here](./1_I18n.md#symfony-routes).
 
 ```yaml
 # config/routes.yaml
@@ -14,11 +15,11 @@ i18n:
               
 i18n_symfony_route:
     path: /{_locale}/i18n/{matching_route_key}
+    controller: App\Controller\DefaultController::symfonyRouteAction
     defaults:
         _i18n:
             translation_keys:
                 matching_route_key: mySymfonyRouteKey
-        _controller: App\Controller\DefaultController::symfonyRouteAction
     requirements:
         matching_route_key: '(%i18n.route.translations.mySymfonyRouteKey%)' ## returns (meine-symfony-route|my-symfony-route)
 ```
@@ -106,7 +107,7 @@ class I18nRoutesAlternateListener implements EventSubscriberInterface
     */
     
     
-     public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents(): array
     {
         return [
             I18nEvents::PATH_ALTERNATE_SYMFONY_ROUTE => 'checkSymfonyRouteAlternate',

--- a/src/I18nBundle/Builder/RouteItemBuilder.php
+++ b/src/I18nBundle/Builder/RouteItemBuilder.php
@@ -138,11 +138,13 @@ class RouteItemBuilder
 
     protected function assertSymfonyRouteItem(RouteItemInterface $routeItem): void
     {
-        if ($routeItem->getRouteAttributesBag()->has(Definitions::ATTRIBUTE_I18N_ROUTE_IDENTIFIER)) {
+        if ($routeItem->getRouteAttributesBag()->has(Definitions::ATTRIBUTE_I18N_ROUTE_TRANSLATION_KEYS_VALIDATED)) {
             return;
         }
 
         $this->assertValidSymfonyRoute($routeItem);
+
+        $routeItem->getRouteAttributesBag()->set(Definitions::ATTRIBUTE_I18N_ROUTE_TRANSLATION_KEYS_VALIDATED, true);
     }
 
     protected function assertDocumentRouteItem(RouteItemInterface $routeItem): void

--- a/src/I18nBundle/Definitions.php
+++ b/src/I18nBundle/Definitions.php
@@ -5,6 +5,7 @@ namespace I18nBundle;
 final class Definitions
 {
     public const ATTRIBUTE_I18N_ROUTE_IDENTIFIER = '_i18n';
+    public const ATTRIBUTE_I18N_ROUTE_TRANSLATION_KEYS_VALIDATED = '_i18n_route_translation_keys_validated';
     public const ATTRIBUTE_I18N_ROUTE_ITEM = '_i18n_route_item';
     public const ATTRIBUTE_I18N_CONTEXT = '_i18n_context';
     public const INTERNATIONAL_COUNTRY_NAMESPACE = 'GLOBAL';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #104 

This is basically but more sophisticated backport of the existing logic from version 3.x:

https://github.com/dachcom-digital/pimcore-i18n/blob/bf1d6a239dbc9b18bc36b5a019b00b41f834b60e/src/I18nBundle/EventListener/I18nStartupListener.php#L125  
