### PR TITLE
Simplify Route Attribute Builder

### DIFF
--- a/docs/90_DocumentRoutes.md
+++ b/docs/90_DocumentRoutes.md
@@ -21,11 +21,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 public function myAction(Request $request) 
 {
-    $parameters = RouteParameterBuilder::buildForEntityWithRequest(
-        \Pimcore\Model\Document::getById(20),
-        [],
-        $request
-    );
+    $document = \Pimcore\Model\Document::getById(20);
+    
+    $parameters = RouteParameterBuilder::buildForEntity($document);
 
     return $this->urlGenerator->generate('', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 }
@@ -43,10 +41,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 protected function execute(InputInterface $input, OutputInterface $output): int
 {
+    $document = \Pimcore\Model\Document::getById(20);
+    
     $parameters = RouteParameterBuilder::buildForEntity(
-        \Pimcore\Model\Document::getById(20),
+        $document,
         [],
-        []
+        [
+            'site' => Site::getByDomain('test-domain1.test')
+        ]
     );
 
     return $this->urlGenerator->generate('', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);

--- a/docs/90_DocumentRoutes.md
+++ b/docs/90_DocumentRoutes.md
@@ -43,13 +43,7 @@ protected function execute(InputInterface $input, OutputInterface $output): int
 {
     $document = \Pimcore\Model\Document::getById(20);
     
-    $parameters = RouteParameterBuilder::buildForEntity(
-        $document,
-        [],
-        [
-            'site' => Site::getByDomain('test-domain1.test')
-        ]
-    );
+    $parameters = RouteParameterBuilder::buildForEntity($document);
 
     return $this->urlGenerator->generate('', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 }

--- a/docs/91_StaticRoutes.md
+++ b/docs/91_StaticRoutes.md
@@ -28,13 +28,18 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 public function myAction(Request $request) 
 {
+    // set object
     $object = \Pimcore\Model\DataObject::getById(20);
     
     $parameters = RouteParameterBuilder::buildForEntity($object);
 
     $linkGeneratorStaticRoute = $this->urlGenerator->generate('', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
     
-    $parameters = RouteParameterBuilder::buildForStaticRoute(['news' => 'my-attribute']);
+    $parameters = RouteParameterBuilder::buildForStaticRoute(
+        [
+            'news' => 'my-attribute'
+        ]
+    );
 
     $instantStaticRoute = $this->urlGenerator->generate('my_static_route', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 }

--- a/docs/92_SymfonyRoutes.md
+++ b/docs/92_SymfonyRoutes.md
@@ -45,9 +45,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 public function myAction(Request $request) 
 {
-    $parameters = RouteParameterBuilder::buildForSymfonyRouteWithRequest(
-        ['foo' => 'bar'],
-        $request
+    $parameters = RouteParameterBuilder::buildForSymfonyRoute(
+        [
+            'foo' => 'bar'
+        ]
     );
 
     $symfonyRoute = $this->urlGenerator->generate('i18n_symfony_route', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
@@ -67,8 +68,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 protected function execute(InputInterface $input, OutputInterface $output): int
 {
     $parameters = RouteParameterBuilder::buildForSymfonyRoute(
-        ['foo' => 'bar'],
-        ['site' => Site::getByDomain('test-domain1.test')]
+        [
+            'foo' => 'bar'
+        ],
+        [
+            'site' => Site::getByDomain('test-domain1.test')
+        ]
     );
 
     $symfonyRoute = $this->urlGenerator->generate('i18n_symfony_route', $parameters, UrlGeneratorInterface::ABSOLUTE_URL);

--- a/src/I18nBundle/Adapter/PathGenerator/Document.php
+++ b/src/I18nBundle/Adapter/PathGenerator/Document.php
@@ -8,6 +8,7 @@ use I18nBundle\Exception\VirtualProxyPathException;
 use I18nBundle\Model\RouteItem\RouteItemInterface;
 use I18nBundle\Model\ZoneSiteInterface;
 use Pimcore\Model\Document as PimcoreDocument;
+use Pimcore\Tool\Frontend;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -237,16 +238,26 @@ class Document extends AbstractPathGenerator
 
     protected function generateLink(RouteItemInterface $routeItem, PimcoreDocument $document, ?ZoneSiteInterface $virtualProxyZoneSite = null): string
     {
+        $context = [];
+
+        if ($virtualProxyZoneSite instanceof ZoneSiteInterface) {
+            $context['virtualProxyZoneSite'] = $virtualProxyZoneSite;
+        }
+
+        if (null !== $site = Frontend::getSiteForDocument($document)) {
+            $context['site'] = $site;
+        }
+
         $routeParameters = [
             Definitions::ATTRIBUTE_I18N_ROUTE_IDENTIFIER => [
                 'type'            => RouteItemInterface::DOCUMENT_ROUTE,
                 'entity'          => $document,
                 'routeName'       => '',
-                'routeParameters' => [],
+                'routeParameters' => [
+                    '_locale' => $document->getProperty('language')
+                ],
                 'routeAttributes' => $routeItem->getRouteAttributes(),
-                'context'         => $virtualProxyZoneSite instanceof ZoneSiteInterface
-                    ? ['virtualProxyZoneSite' => $virtualProxyZoneSite]
-                    : []
+                'context'         => $context
             ]
         ];
 

--- a/src/I18nBundle/Context/I18nContext.php
+++ b/src/I18nBundle/Context/I18nContext.php
@@ -291,7 +291,9 @@ class I18nContext implements I18nContextInterface
                     return $site->getLocale();
                 }, $sites))
             ));
-        } elseif (count($activeSites) > 1) {
+        }
+
+        if (count($activeSites) > 1) {
             throw new ZoneSiteNotFoundException(sprintf(
                 'Ambiguous locale definition for zone (Id %d) sites detected ("%s" was requested, multiple paths [%s] matched).',
                 $zoneIdentifier,

--- a/src/I18nBundle/EventListener/AdminSiteListener.php
+++ b/src/I18nBundle/EventListener/AdminSiteListener.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace I18nBundle\EventListener;
+
+use I18nBundle\Resolver\PimcoreAdminSiteResolverInterface;
+use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Http\RequestHelper;
+use Pimcore\Model\Site;
+use Pimcore\Tool\Frontend;
+use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AdminSiteListener implements EventSubscriberInterface
+{
+    use PimcoreContextAwareTrait;
+
+    public function __construct(
+        protected RequestHelper $requestHelper,
+        protected PimcoreAdminSiteResolverInterface $adminSiteResolver
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // run after pimcore DocumentFallbackListener (20)
+            KernelEvents::REQUEST => ['onKernelRequest', 19],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $this->resolveAdminContextSite($event->getRequest());
+    }
+
+    protected function resolveAdminContextSite(Request $request): void
+    {
+        if (!$this->requestHelper->isFrontendRequestByAdmin($request)) {
+            return;
+        }
+
+        if (!$request->attributes->has(DynamicRouter::CONTENT_KEY)) {
+            return;
+        }
+
+
+        $site = Frontend::getSiteForDocument($request->attributes->get(DynamicRouter::CONTENT_KEY));
+
+        if (!$site instanceof Site) {
+            return;
+        }
+
+        $this->adminSiteResolver->setAdminSite($request, $site);
+    }
+}

--- a/src/I18nBundle/Manager/I18nContextManager.php
+++ b/src/I18nBundle/Manager/I18nContextManager.php
@@ -18,7 +18,6 @@ use I18nBundle\Model\ZoneInterface;
 use I18nBundle\Model\RouteItem\RouteItemInterface;
 use I18nBundle\Registry\LocaleProviderRegistry;
 use I18nBundle\Registry\PathGeneratorRegistry;
-use Pimcore\Http\RequestHelper;
 use Pimcore\Model\Document;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,7 +25,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class I18nContextManager
 {
     public function __construct(
-        protected RequestHelper $requestHelper,
         protected ZoneBuilder $zoneBuilder,
         protected ZoneSitesBuilder $zoneSitesBuilder,
         protected RouteItemBuilder $routeItemBuilder,
@@ -140,5 +138,4 @@ class I18nContextManager
 
         return $this->pathGeneratorRegistry->get($pathGeneratorIdentifier);
     }
-
 }

--- a/src/I18nBundle/Modifier/RouteItem/RouteItemModifier.php
+++ b/src/I18nBundle/Modifier/RouteItem/RouteItemModifier.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem;
+
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use I18nBundle\Modifier\RouteItem\Type\RouteItemModifierInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class RouteItemModifier
+{
+    protected iterable $modifier;
+
+    public function __construct(iterable $modifier = [])
+    {
+        $this->modifier = $modifier;
+    }
+
+    public function modifyByParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context = []): RouteItemInterface
+    {
+        /** @var  RouteItemModifierInterface $modifier */
+        foreach ($this->modifier as $modifier) {
+            if ($modifier->supportParameters($type, $routeItem, $parameters, $context)) {
+                $modifier->modifyByParameters($routeItem, $parameters, $context);
+            }
+        }
+
+        return $routeItem;
+    }
+
+    public function modifyByRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context = []): RouteItemInterface
+    {
+        /** @var  RouteItemModifierInterface $modifier */
+        foreach ($this->modifier as $modifier) {
+            if ($modifier->supportRequest($type, $routeItem, $request, $context)) {
+                $modifier->modifyByRequest($routeItem, $request, $context);
+            }
+        }
+
+        return $routeItem;
+    }
+}

--- a/src/I18nBundle/Modifier/RouteItem/Type/DocumentRouteModifier.php
+++ b/src/I18nBundle/Modifier/RouteItem/Type/DocumentRouteModifier.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem\Type;
+
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use Pimcore\Model\Document;
+use Pimcore\Tool\Frontend;
+use Symfony\Component\HttpFoundation\Request;
+
+class DocumentRouteModifier implements RouteItemModifierInterface
+{
+    public function supportParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context): bool
+    {
+        if ($type !== RouteItemInterface::DOCUMENT_ROUTE) {
+            return false;
+        }
+
+        if (!$routeItem->getEntity() instanceof Document) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context): bool
+    {
+        if ($type !== RouteItemInterface::DOCUMENT_ROUTE) {
+            return false;
+        }
+
+        if (!array_key_exists('document', $context)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function modifyByParameters(RouteItemInterface $routeItem, array $parameters, array $context): void
+    {
+        /** @var Document $document */
+        $document = $routeItem->getEntity();
+
+        $routeItem->getRouteParametersBag()->set('_locale', $document->getProperty('language'));
+
+        if (!$routeItem->getRouteContextBag()->has('site') && null !== $site = Frontend::getSiteForDocument($document)) {
+            $routeItem->getRouteContextBag()->set('site', $site);
+        }
+    }
+
+    public function modifyByRequest(RouteItemInterface $routeItem, Request $request, array $context): void
+    {
+        /** @var Document $document */
+        $document = $context['document'];
+
+        $routeItem->setEntity($document);
+        $routeItem->getRouteParametersBag()->set('_locale', $document->getProperty('language'));
+    }
+}

--- a/src/I18nBundle/Modifier/RouteItem/Type/RequestAwareModifier.php
+++ b/src/I18nBundle/Modifier/RouteItem/Type/RequestAwareModifier.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem\Type;
+
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use I18nBundle\Resolver\PimcoreAdminSiteResolverInterface;
+use Pimcore\Http\Request\Resolver\SiteResolver;
+use Pimcore\Http\RequestHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RequestAwareModifier implements RouteItemModifierInterface
+{
+    public function __construct(
+        protected RequestStack $requestStack,
+        protected RequestHelper $requestHelper
+    ) {
+    }
+
+    public function supportParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context): bool
+    {
+        return $this->requestStack->getMainRequest() instanceof Request;
+    }
+
+    public function supportRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context): bool
+    {
+        return true;
+    }
+
+    public function modifyByParameters(RouteItemInterface $routeItem, array $parameters, array $context): void
+    {
+        if (!$this->requestStack->getMainRequest() instanceof Request) {
+            return;
+        }
+
+        $this->modify($routeItem, $this->requestStack->getMainRequest());
+    }
+
+    public function modifyByRequest(RouteItemInterface $routeItem, Request $request, array $context): void
+    {
+        $this->modify($routeItem, $request);
+    }
+
+    protected function modify(RouteItemInterface $routeItem, Request $request): void
+    {
+        $isFrontendRequestByAdmin = $this->requestHelper->isFrontendRequestByAdmin($request);
+
+        if (!$routeItem->getRouteContextBag()->has('site') || $routeItem->getRouteContextBag()->get('site') === null) {
+            if ($request->attributes->has(SiteResolver::ATTRIBUTE_SITE)) {
+                $routeItem->getRouteContextBag()->set('site', $request->attributes->get(SiteResolver::ATTRIBUTE_SITE));
+            } elseif ($request->attributes->has(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE)) {
+                $routeItem->getRouteContextBag()->set('site', $request->attributes->get(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE));
+            }
+        }
+
+        if ($request->attributes->has('_locale') && !$routeItem->getRouteParametersBag()->has('_locale')) {
+            $routeItem->getRouteParametersBag()->set('_locale', $request->getLocale());
+        }
+
+        $routeItem->getRouteContextBag()->set('isFrontendRequestByAdmin', $isFrontendRequestByAdmin);
+    }
+}

--- a/src/I18nBundle/Modifier/RouteItem/Type/RouteItemModifierInterface.php
+++ b/src/I18nBundle/Modifier/RouteItem/Type/RouteItemModifierInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem\Type;
+
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+interface RouteItemModifierInterface
+{
+    public function supportParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context): bool;
+
+    public function supportRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context): bool;
+
+    public function modifyByParameters(RouteItemInterface $routeItem, array $parameters, array $context): void;
+
+    public function modifyByRequest(RouteItemInterface $routeItem, Request $request, array $context): void;
+}

--- a/src/I18nBundle/Modifier/RouteItem/Type/StaticRouteModifier.php
+++ b/src/I18nBundle/Modifier/RouteItem/Type/StaticRouteModifier.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem\Type;
+
+use I18nBundle\LinkGenerator\I18nLinkGeneratorInterface;
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
+use Pimcore\Model\DataObject\Concrete;
+use Symfony\Component\HttpFoundation\Request;
+
+class StaticRouteModifier implements RouteItemModifierInterface
+{
+    public function supportParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context): bool
+    {
+        if ($type !== RouteItemInterface::STATIC_ROUTE) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context): bool
+    {
+        if ($type !== RouteItemInterface::STATIC_ROUTE) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function modifyByParameters(RouteItemInterface $routeItem, array $parameters, array $context): void
+    {
+        if (!$routeItem->hasRouteName() && !$routeItem->hasEntity()) {
+            throw new \Exception(sprintf('Cannot build static route item. Either route name or entity must be present'));
+        }
+
+        if ($routeItem->hasEntity()) {
+            $this->assertValidLinkGenerator($routeItem);
+        }
+    }
+
+    public function modifyByRequest(RouteItemInterface $routeItem, Request $request, array $context): void
+    {
+        $routeItem->getRouteAttributesBag()->add($request->attributes->all());
+    }
+
+    protected function assertValidLinkGenerator(RouteItemInterface $routeItem): void
+    {
+        $entity = $routeItem->getEntity();
+
+        if (!$entity instanceof Concrete) {
+            throw new \Exception(sprintf('I18n object zone generation error: Entity needs to be an instance of "%s", "%s" given.', Concrete::class, get_class($entity)));
+        }
+
+        $linkGenerator = $entity->getClass()?->getLinkGenerator();
+        if (!$linkGenerator instanceof LinkGeneratorInterface) {
+            throw new \Exception(
+                sprintf(
+                    'I18n object zone generation error: No link generator for entity "%s" found (If you have declared your link generator as service, make sure it is public)',
+                    get_class($entity)
+                )
+            );
+        }
+
+        if (!$linkGenerator instanceof I18nLinkGeneratorInterface) {
+            throw new \Exception(
+                sprintf(
+                    'I18n object zone generation error: Your link generator "%s" needs to be an instance of %s.',
+                    get_class($linkGenerator),
+                    I18nLinkGeneratorInterface::class
+                )
+            );
+        }
+
+        $routeItem->setRouteName($linkGenerator->getStaticRouteName($entity));
+    }
+}

--- a/src/I18nBundle/Modifier/RouteItem/Type/SymfonyRouteModifier.php
+++ b/src/I18nBundle/Modifier/RouteItem/Type/SymfonyRouteModifier.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace I18nBundle\Modifier\RouteItem\Type;
+
+use I18nBundle\Definitions;
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
+
+class SymfonyRouteModifier implements RouteItemModifierInterface
+{
+    public function supportParameters(string $type, RouteItemInterface $routeItem, array $parameters, array $context): bool
+    {
+        if ($type !== RouteItemInterface::SYMFONY_ROUTE) {
+            return false;
+        }
+
+        if ($routeItem->getRouteAttributesBag()->has(Definitions::ATTRIBUTE_I18N_ROUTE_TRANSLATION_KEYS_VALIDATED)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportRequest(string $type, RouteItemInterface $routeItem, Request $request, array $context): bool
+    {
+        if ($type !== RouteItemInterface::SYMFONY_ROUTE) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function modifyByParameters(RouteItemInterface $routeItem, array $parameters, array $context): void
+    {
+        $this->assertValidSymfonyRoute($routeItem, $context);
+
+        $routeItem->getRouteAttributesBag()->set(Definitions::ATTRIBUTE_I18N_ROUTE_TRANSLATION_KEYS_VALIDATED, true);
+    }
+
+    public function modifyByRequest(RouteItemInterface $routeItem, Request $request, array $context): void
+    {
+        $routeItem->getRouteAttributesBag()->add($request->attributes->all());
+
+        $routeParameters = $request->attributes->get('_route_params', []);
+        if (isset($routeParameters['_locale']) && !$routeItem->getRouteParametersBag()->has('_locale')) {
+            $routeItem->getRouteParametersBag()->set('_locale', $request->getLocale());
+        }
+    }
+
+    protected function assertValidSymfonyRoute(RouteItemInterface $routeItem, array $context): void
+    {
+        $router = $context['router'];
+
+        if ($router === null) {
+            throw new \Exception('Symfony RouteItem error: Framework router not found. cannot assert symfony route');
+        }
+
+        $routeName = $routeItem->getRouteName();
+        $locale = $routeItem->getLocaleFragment();
+
+        /** @var CompiledUrlGenerator $generator */
+        $generator = $router->getGenerator();
+
+        if (!$generator instanceof CompiledUrlGenerator) {
+            throw new \Exception(
+                sprintf('Symfony RouteItem error: Url generator needs to be instance of "%s", "%s" given.',
+                    CompiledUrlGenerator::class,
+                    get_class($generator)
+                )
+            );
+        }
+
+        /**
+         * Oh lawd. This is terrible.
+         * Can we do that better instead of stealing private properties like this?
+         */
+        $compiledRoutes = \Closure::bind(static function & (CompiledUrlGenerator $generator) {
+            return $generator->compiledRoutes;
+        }, null, $generator)($generator);
+
+        $symfonyRoute = null;
+        if (isset($compiledRoutes[$routeName])) {
+            $symfonyRoute = $compiledRoutes[$routeName];
+        }
+
+        if ($symfonyRoute === null && !empty($locale)) {
+            $localizedRouteName = sprintf('%s.%s', $routeName, $locale);
+            if (isset($compiledRoutes[$localizedRouteName])) {
+                $symfonyRoute = $compiledRoutes[$localizedRouteName];
+            }
+        }
+
+        if ($symfonyRoute === null) {
+            throw new \Exception(sprintf('symfony route "%s" not found', $routeName));
+        }
+
+        $defaults = $symfonyRoute[1];
+
+        if (!isset($defaults[Definitions::ATTRIBUTE_I18N_ROUTE_IDENTIFIER])) {
+            throw new \Exception(sprintf('"%s" symfony route is not configured as i18n route. please add defaults._i18n to your route configuration.', $routeName));
+        }
+
+        $i18nDefaults = $defaults[Definitions::ATTRIBUTE_I18N_ROUTE_IDENTIFIER];
+
+        if (!is_array($i18nDefaults)) {
+            return;
+        }
+
+        if (isset($i18nDefaults['translation_keys'])) {
+            $routeItem->getRouteAttributesBag()->set('_i18n_translation_keys', $i18nDefaults['translation_keys']);
+        }
+    }
+
+}

--- a/src/I18nBundle/Modifier/RouteModifier.php
+++ b/src/I18nBundle/Modifier/RouteModifier.php
@@ -11,22 +11,17 @@ use I18nBundle\Manager\I18nContextManager;
 use I18nBundle\Model\RouteItem\RouteItemInterface;
 use I18nBundle\Model\ZoneInterface;
 use I18nBundle\Model\ZoneSiteInterface;
-use I18nBundle\Resolver\PimcoreAdminSiteResolverInterface;
 use I18nBundle\Tool\System;
 use I18nBundle\Transformer\LinkGeneratorRouteItemTransformer;
-use Pimcore\Http\Request\Resolver\SiteResolver;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class RouteModifier
 {
     public function __construct(
-        protected RequestStack $requestStack,
         protected LinkGeneratorRouteItemTransformer $linkGeneratorRouteItemTransformer,
         protected I18nContextManager $i18nContextManager
     ) {
@@ -246,8 +241,6 @@ class RouteModifier
 
     protected function validateRouteParameters(string $name, string $routeType, array $parameters): array
     {
-        $parameters = $this->assertRequestParameters($parameters);
-
         unset($parameters['type']);
 
         if (!empty($name)) {
@@ -268,26 +261,4 @@ class RouteModifier
         return $parameters;
     }
 
-    protected function assertRequestParameters(array $i18nParameters): array
-    {
-        $mainRequest = $this->requestStack->getMainRequest();
-
-        if (!$mainRequest instanceof Request) {
-            return $i18nParameters;
-        }
-
-        if (!isset($i18nParameters['context']['site'])) {
-            if ($mainRequest->attributes->has(SiteResolver::ATTRIBUTE_SITE)) {
-                $i18nParameters['context']['site'] = $mainRequest->attributes->get(SiteResolver::ATTRIBUTE_SITE);
-            } elseif ($mainRequest->attributes->has(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE)) {
-                $i18nParameters['context']['site'] = $mainRequest->attributes->get(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE);
-            }
-        }
-
-        if (!isset($i18nParameters['routeParameters']['_locale']) && $mainRequest->attributes->has('_locale')) {
-            $i18nParameters['routeParameters']['_locale'] = $mainRequest->getLocale();
-        }
-
-        return $i18nParameters;
-    }
 }

--- a/src/I18nBundle/Modifier/RouteModifier.php
+++ b/src/I18nBundle/Modifier/RouteModifier.php
@@ -11,20 +11,26 @@ use I18nBundle\Manager\I18nContextManager;
 use I18nBundle\Model\RouteItem\RouteItemInterface;
 use I18nBundle\Model\ZoneInterface;
 use I18nBundle\Model\ZoneSiteInterface;
+use I18nBundle\Resolver\PimcoreAdminSiteResolverInterface;
 use I18nBundle\Tool\System;
 use I18nBundle\Transformer\LinkGeneratorRouteItemTransformer;
+use Pimcore\Http\Request\Resolver\SiteResolver;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class RouteModifier
 {
     public function __construct(
+        protected RequestStack $requestStack,
         protected LinkGeneratorRouteItemTransformer $linkGeneratorRouteItemTransformer,
         protected I18nContextManager $i18nContextManager
-    ) {}
+    ) {
+    }
 
     public function generateI18nContext(string $name, $parameters = []): ?I18nContextInterface
     {
@@ -75,7 +81,8 @@ class RouteModifier
                 continue;
             }
 
-            $i18nContext->getRouteItem()->getRouteParametersBag()->set($routeKey, $this->translateDynamicRouteKey($zone, $i18nContext->getRouteItem(), $translationKey, $locale));
+            $i18nContext->getRouteItem()->getRouteParametersBag()->set($routeKey,
+                $this->translateDynamicRouteKey($zone, $i18nContext->getRouteItem(), $translationKey, $locale));
         }
     }
 
@@ -239,6 +246,8 @@ class RouteModifier
 
     protected function validateRouteParameters(string $name, string $routeType, array $parameters): array
     {
+        $parameters = $this->assertRequestParameters($parameters);
+
         unset($parameters['type']);
 
         if (!empty($name)) {
@@ -257,5 +266,28 @@ class RouteModifier
         }
 
         return $parameters;
+    }
+
+    protected function assertRequestParameters(array $i18nParameters): array
+    {
+        $mainRequest = $this->requestStack->getMainRequest();
+
+        if (!$mainRequest instanceof Request) {
+            return $i18nParameters;
+        }
+
+        if (!isset($i18nParameters['context']['site'])) {
+            if ($mainRequest->attributes->has(SiteResolver::ATTRIBUTE_SITE)) {
+                $i18nParameters['context']['site'] = $mainRequest->attributes->get(SiteResolver::ATTRIBUTE_SITE);
+            } elseif ($mainRequest->attributes->has(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE)) {
+                $i18nParameters['context']['site'] = $mainRequest->attributes->get(PimcoreAdminSiteResolverInterface::ATTRIBUTE_ADMIN_EDIT_MODE_SITE);
+            }
+        }
+
+        if (!isset($i18nParameters['routeParameters']['_locale']) && $mainRequest->attributes->has('_locale')) {
+            $i18nParameters['routeParameters']['_locale'] = $mainRequest->getLocale();
+        }
+
+        return $i18nParameters;
     }
 }

--- a/src/I18nBundle/Resolver/PimcoreAdminSiteResolver.php
+++ b/src/I18nBundle/Resolver/PimcoreAdminSiteResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace I18nBundle\Resolver;
+
+use Pimcore\Http\Request\Resolver\SiteResolver;
+use Pimcore\Http\RequestHelper;
+use Pimcore\Model\Site;
+use Symfony\Component\HttpFoundation\Request;
+
+class PimcoreAdminSiteResolver implements PimcoreAdminSiteResolverInterface
+{
+    protected SiteResolver $siteResolver;
+    protected RequestHelper $requestHelper;
+
+    public function __construct(
+        SiteResolver $siteResolver,
+        RequestHelper $requestHelper
+    ) {
+        $this->siteResolver = $siteResolver;
+        $this->requestHelper = $requestHelper;
+    }
+
+    public function setAdminSite(Request $request, Site $site): void
+    {
+        $request->attributes->set(static::ATTRIBUTE_ADMIN_EDIT_MODE_SITE, $site);
+    }
+
+    public function hasAdminSite(Request $request): bool
+    {
+        if ($request->attributes->has(self::ATTRIBUTE_ADMIN_EDIT_MODE_SITE)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getAdminSite(Request $request): ?Site
+    {
+        if ($request->attributes->has(self::ATTRIBUTE_ADMIN_EDIT_MODE_SITE)) {
+            return $request->attributes->get(self::ATTRIBUTE_ADMIN_EDIT_MODE_SITE);
+        }
+
+        return null;
+    }
+}

--- a/src/I18nBundle/Resolver/PimcoreAdminSiteResolverInterface.php
+++ b/src/I18nBundle/Resolver/PimcoreAdminSiteResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace I18nBundle\Resolver;
+
+use Pimcore\Model\Site;
+use Symfony\Component\HttpFoundation\Request;
+
+interface PimcoreAdminSiteResolverInterface
+{
+    public const ATTRIBUTE_ADMIN_EDIT_MODE_SITE = '_editmode_admin_site';
+
+    public function getAdminSite(Request $request): ?Site;
+
+    public function hasAdminSite(Request $request): bool;
+
+    public function setAdminSite(Request $request, Site $site): void;
+}

--- a/src/I18nBundle/Resources/config/services/event.yml
+++ b/src/I18nBundle/Resources/config/services/event.yml
@@ -25,6 +25,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    # event: attach site in admin context (frontend edit mode)
+    I18nBundle\EventListener\AdminSiteListener:
+        tags:
+            - { name: kernel.event_subscriber }
+
     # event: log context switch
     I18nBundle\EventListener\ContextSwitchDetectorListener:
         tags:

--- a/src/I18nBundle/Resources/config/services/resolver.yml
+++ b/src/I18nBundle/Resources/config/services/resolver.yml
@@ -5,5 +5,8 @@ services:
         autoconfigure: true
         public: false
 
+    I18nBundle\Resolver\PimcoreAdminSiteResolverInterface: '@I18nBundle\Resolver\PimcoreAdminSiteResolver'
+    I18nBundle\Resolver\PimcoreAdminSiteResolver: ~
+
     I18nBundle\Resolver\PimcoreDocumentResolverInterface: '@I18nBundle\Resolver\PimcoreDocumentResolver'
     I18nBundle\Resolver\PimcoreDocumentResolver: ~

--- a/src/I18nBundle/Resources/config/services/route.yml
+++ b/src/I18nBundle/Resources/config/services/route.yml
@@ -1,7 +1,28 @@
 services:
-
-    I18nBundle\Factory\RouteItemFactory:
+    _defaults:
         autowire: true
+
+    I18nBundle\Factory\RouteItemFactory: ~
 
     I18nBundle\Modifier\RouteModifier:
         autowire: true
+
+    I18nBundle\Modifier\RouteItem\RouteItemModifier:
+        arguments:
+            - !tagged_iterator i18n.modifier.route_item
+
+    I18nBundle\Modifier\RouteItem\Type\DocumentRouteModifier:
+        tags:
+            - { name: i18n.modifier.route_item }
+
+    I18nBundle\Modifier\RouteItem\Type\StaticRouteModifier:
+        tags:
+            - { name: i18n.modifier.route_item }
+
+    I18nBundle\Modifier\RouteItem\Type\SymfonyRouteModifier:
+        tags:
+            - { name: i18n.modifier.route_item }
+
+    I18nBundle\Modifier\RouteItem\Type\RequestAwareModifier:
+        tags:
+            - { name: i18n.modifier.route_item }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR:
- always use the main request (to simplify site context)
- deprecates `build*WithRequest` methods in `RouteParameterBuilder`: We're now adding site and locale in every `$router->generate()` call, if a valid request is given
- introduces `PimcoreAdminSiteResolver`: Resolve Site in Editmode, if a document has been found: This allows as to use i18n context in editmode (`frontendRequestByAdmin`) 

Fixes:
- #124
- #123