### PR TITLE
Writing http errors to DB analogue to pimcore

### DIFF
--- a/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
+++ b/src/I18nBundle/EventListener/Frontend/ResponseExceptionListener.php
@@ -97,7 +97,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
      */
     protected function handleErrorPage(ExceptionEvent $event): void
     {
-        if (false && \Pimcore::inDebugMode()) {
+        if (\Pimcore::inDebugMode()) {
             return;
         }
 
@@ -117,7 +117,6 @@ class ResponseExceptionListener implements EventSubscriberInterface
          * We need a document to initialize a valid zone!
          */
         $document = $this->determineErrorDocument($event->getRequest());
-
         $this->logToHttpErrorLog($event->getRequest(), $statusCode);
 
         if (!$document instanceof Document) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Allows the http error log in the pimcore backend to be populated again
