### PR TITLE
i18n object preview button

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Notes
 
+## 5.1.0
+- [FEATURE] pimcore backend: object preview button
 ## 5.0.6
 - [IMPROVEMENT] Try to determinate locale and site when inline renderer is active (mostly via `checkMissingRequiredEditable()`)
 ## 5.0.5

--- a/config/services/event.yaml
+++ b/config/services/event.yaml
@@ -30,6 +30,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    # event: add backend assets
+    I18nBundle\EventListener\Admin\AssetListener:
+        tags:
+            - { name: kernel.event_subscriber }
+
     # event: log context switch
     I18nBundle\EventListener\ContextSwitchDetectorListener:
         tags:

--- a/public/js/backend/i18n-object-preview.js
+++ b/public/js/backend/i18n-object-preview.js
@@ -1,0 +1,84 @@
+pimcore.registerNS('pimcore.plugin.i18n.objectPreview');
+pimcore.plugin.i18n.objectPreview = Class.create({
+
+    objectInstance: null,
+
+    initialize: function () {
+        document.addEventListener(pimcore.events.postOpenObject, (e) => {
+            this.postOpenObject(e.detail.object, e.detail.type);
+        });
+    },
+
+    postOpenObject: function(objectInstance) {
+        if (!objectInstance.data.hasPreview) {
+            return;
+        }
+
+        this.objectInstance = objectInstance;
+
+        let sitesStore = pimcore.globalmanager.get('sites');
+        if (sitesStore.isLoading()) {
+            sitesStore.addListener('load', () => this.modifyObjectPreviewBtn());
+            return;
+        }
+
+        this.modifyObjectPreviewBtn();
+    },
+
+    modifyObjectPreviewBtn: function() {
+        let locales = pimcore.settings.websiteLanguages;
+        let sitesStore = pimcore.globalmanager.get('sites');
+
+        let index = this.objectInstance.toolbar.items.length;
+        let origPreviewButton = this.objectInstance.toolbar.items.find(e => typeof e === 'object' && e.iconCls === 'pimcore_material_icon_preview pimcore_material_icon')
+
+        if (origPreviewButton) {
+            index = this.objectInstance.toolbar.items.indexOf(origPreviewButton);
+            this.objectInstance.toolbar.remove(origPreviewButton);
+        }
+
+        let previewButton = this.objectInstance.toolbar.insert(index, {
+            tooltip: t('open'),
+            scale: 'medium',
+            iconCls: 'pimcore_material_icon_preview pimcore_material_icon',
+            menu: []
+        });
+
+        sitesStore.each((siteItem) => {
+           if (locales.length === 1) {
+               let locale = locales[0];
+               previewButton.menu.insert({
+                   text: siteItem.data.domain + ' [' + locale + ']',
+                   handler: () => this.openObjectPreview({
+                       i18n_locale: locale,
+                       i18n_site: siteItem.data.id
+                   })
+               })
+           } else {
+               previewButton.menu.insert({
+                   text: siteItem.data.domain,
+                   menu: locales.map(locale => new Object({
+                       text: locale,
+                       handler: () => this.openObjectPreview({
+                           i18n_locale: locale,
+                           i18n_site: siteItem.data.id
+                       })
+                   }))
+               });
+           }
+        });
+    },
+
+    openObjectPreview: function(params) {
+        let url = Routing.generate('pimcore_admin_dataobject_dataobject_preview', {
+            id: this.objectInstance.data.general.id,
+            time: (new Date()).getTime(),
+            ...params
+        });
+        this.objectInstance.saveToSession(() => {
+            window.open(url);
+        })
+    }
+
+});
+new pimcore.plugin.i18n.objectPreview();

--- a/src/EventListener/Admin/AssetListener.php
+++ b/src/EventListener/Admin/AssetListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace I18nBundle\EventListener\Admin;
+
+use Pimcore\Event\BundleManager\PathsEvent;
+use Pimcore\Event\BundleManagerEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AssetListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BundleManagerEvents::JS_PATHS => ['addJsFiles', -50],
+        ];
+    }
+
+    public function addJsFiles(PathsEvent $event): void
+    {
+        $event->addPaths([
+            '/bundles/i18n/js/backend/i18n-object-preview.js',
+        ]);
+    }
+}

--- a/src/EventListener/I18nPreviewListener.php
+++ b/src/EventListener/I18nPreviewListener.php
@@ -94,7 +94,7 @@ class I18nPreviewListener implements EventSubscriberInterface
             return;
         }
 
-        $path = $siteIdentifier !== null ? $this->siteResolver->getSitePath($request) : $request;
+        $path = $siteIdentifier ? $this->siteResolver->getSitePath($request) : $request;
         $nearestDocument = $this->documentService->getNearestDocumentByPath($path, false, $this->nearestDocumentTypes);
 
         if (!$nearestDocument instanceof Document) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR modifies pimcore's preview button for data objects. If an object supports preview, the original preview button is modified into a dropdown, with all available sites and locales. The selection (site, locale) will be passed as `i18n_` parameter to the object preview. If configured correctly (i18n's preview generator is used, see [pimcore preview generator](https://github.com/dachcom-digital/pimcore-i18n/blob/master/docs/1_I18n.md#pimcore-preview-generator)), this PR fixes the object preview button. 
