### PR TITLE
Use default config for sites which do not have a zone

### DIFF
--- a/src/Builder/ZoneBuilder.php
+++ b/src/Builder/ZoneBuilder.php
@@ -57,7 +57,7 @@ class ZoneBuilder
         // no valid zone found. use default one.
         if ($validZone === false) {
             $zoneConfig = $this->configuration->getConfigNode();
-            return $this->createZone($zoneConfig, 'dynamic_zone_'.$site->getId(), 'dynamic_zone_'.$site->getId(), [$site->getMainDomain()]);
+            return $this->createZone($zoneConfig, $site->getId(), 'dynamic_zone_'.$site->getId(), [$site->getMainDomain()]);
         }
 
         return $this->createZone($zoneConfig['config'], $zoneConfig['id'], $zoneConfig['name'], $zoneConfig['domains']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | not sure
| Deprecations? | no

If you have configured zones as described in https://github.com/dachcom-digital/pimcore-i18n/blob/master/docs/20_Zones.md and afterwards add a new site `/new-site`, add localization pages like `/new-site/de` and assign it a language, you will get the error message:
> This document can not be edited because it will be skipped during a i18n redirection or does not have a valid language property.
No i18n zone for domain "new-site.example.org" found. Maybe there is a typo in your i18n.zones.domains mapping?

Although https://github.com/dachcom-digital/pimcore-i18n/blob/c7381c129a6cda55347c61735284b1e3b300dceb/src/Builder/ZoneBuilder.php#L57-L60 pretends `// no valid zone found. use default one.`, it throws the exception which does not fall back to using default zone.

With this PR a temporary zone based on the default configuration will get created for the main domain of the site.
