### PR TITLE
[Routing] Data Object Routes

### DIFF
--- a/config/services/adapter.yaml
+++ b/config/services/adapter.yaml
@@ -42,6 +42,14 @@ services:
         tags:
             - { name: i18n.adapter.path.generator, alias: document }
 
+    I18nBundle\Adapter\PathGenerator\DataObject:
+        parent: I18nBundle\Adapter\PathGenerator\AbstractPathGenerator
+        arguments:
+            - '@router'
+            - '@event_dispatcher'
+        tags:
+            - { name: i18n.adapter.path.generator, alias: data_object }
+
 
     #
     # Adapter: ReDirector

--- a/src/Adapter/PathGenerator/DataObject.php
+++ b/src/Adapter/PathGenerator/DataObject.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under two different licenses:
+ *   - GNU General Public License version 3 (GPLv3)
+ *   - DACHCOM Commercial License (DCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) DACHCOM.DIGITAL AG (https://www.dachcom-digital.com)
+ * @license    GPLv3 and DCL
+ */
+
+namespace I18nBundle\Adapter\PathGenerator;
+
+use I18nBundle\Context\I18nContextInterface;
+use I18nBundle\I18nEvents;
+use I18nBundle\Model\RouteItem\AlternateRouteItemInterface;
+use I18nBundle\Model\RouteItem\RouteItemInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class DataObject extends DynamicRoute
+{
+    public function __construct(
+        protected RouterInterface $router,
+        protected EventDispatcherInterface $eventDispatcher
+    ) {}
+
+    public function getUrls(I18nContextInterface $i18nContext, bool $onlyShowRootLanguages = false): array
+    {
+        return $this->buildAlternateRoutesStack(
+            $i18nContext,
+            RouteItemInterface::DATA_OBJECT_ROUTE,
+            I18nEvents::PATH_ALTERNATE_DATA_OBJECT_ROUTE
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function generateLink(AlternateRouteItemInterface $routeItem): string
+    {
+        $routeParameters = $this->alternateRouteItemTransformer->reverseTransformToArray($routeItem, [
+            'type' => RouteItemInterface::DATA_OBJECT_ROUTE,
+        ]);
+
+        if ($routeItem->getEntity() === null || $routeItem->getUrlSlug() === null) {
+            throw new \RuntimeException(
+                'Cannot create Data Object route URL. Object and/or UrlSlug is missing!'
+            );
+        }
+
+        return $this->router->generate(
+            $routeItem->getRouteName(),
+            $routeParameters,
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+}

--- a/src/Builder/RouteItemBuilder.php
+++ b/src/Builder/RouteItemBuilder.php
@@ -83,6 +83,10 @@ class RouteItemBuilder
             $routeItem = $this->routeItemFactory->create(RouteItemInterface::STATIC_ROUTE, false);
         } elseif (str_starts_with($currentRouteName, 'document_')) {
             $routeItem = $this->routeItemFactory->create(RouteItemInterface::DOCUMENT_ROUTE, false);
+        } elseif (str_starts_with($currentRouteName, 'data_object_')) {
+            $routeItem = $this->routeItemFactory->create(RouteItemInterface::DATA_OBJECT_ROUTE, true);
+            $routeItem->setEntity($baseRequest->attributes->get('object'));
+            $routeItem->setUrlSlug($baseRequest->attributes->get('urlSlug'));
         } elseif ($baseRequest->attributes->has(Definitions::ATTRIBUTE_I18N_ROUTE_IDENTIFIER)) {
             $routeItem = $this->routeItemFactory->create(RouteItemInterface::SYMFONY_ROUTE, false);
         }

--- a/src/I18nEvents.php
+++ b/src/I18nEvents.php
@@ -18,6 +18,7 @@ final class I18nEvents
     public const CONTEXT_SWITCH = 'i18n.switch';
     public const PATH_ALTERNATE_STATIC_ROUTE = 'i18n.path.static_route.alternate';
     public const PATH_ALTERNATE_SYMFONY_ROUTE = 'i18n.path.symfony_route.alternate';
+    public const PATH_ALTERNATE_DATA_OBJECT_ROUTE = 'i18n.path.data_object_route.alternate';
     public const PREVIEW_CONFIG_GENERATION = 'i18n.preview.config_generation';
     public const PREVIEW_URL_GENERATION = 'i18n.preview.url_generation';
 }

--- a/src/Model/RouteItem/BaseRouteItem.php
+++ b/src/Model/RouteItem/BaseRouteItem.php
@@ -13,6 +13,7 @@
 
 namespace I18nBundle\Model\RouteItem;
 
+use Pimcore\Model\DataObject\Data\UrlSlug;
 use Pimcore\Model\Element\ElementInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -25,6 +26,7 @@ abstract class BaseRouteItem
     protected ParameterBag $routeParameters;
     protected ParameterBag $routeAttributes;
     protected ParameterBag $routeContext;
+    protected ?UrlSlug $urlSlug = null;
 
     public function __construct(string $type, bool $headless)
     {
@@ -32,6 +34,7 @@ abstract class BaseRouteItem
             RouteItemInterface::DOCUMENT_ROUTE,
             RouteItemInterface::SYMFONY_ROUTE,
             RouteItemInterface::STATIC_ROUTE,
+            RouteItemInterface::DATA_OBJECT_ROUTE,
         ], true)) {
             throw new \Exception(sprintf('Invalid RouteItem type "%s"', $type));
         }
@@ -126,5 +129,15 @@ abstract class BaseRouteItem
     public function setRouteName(?string $routeName): void
     {
         $this->routeName = $routeName;
+    }
+
+    public function getUrlSlug(): ?UrlSlug
+    {
+        return $this->urlSlug;
+    }
+
+    public function setUrlSlug(?UrlSlug $urlSlug): void
+    {
+        $this->urlSlug = $urlSlug;
     }
 }

--- a/src/Model/RouteItem/BaseRouteItemInterface.php
+++ b/src/Model/RouteItem/BaseRouteItemInterface.php
@@ -13,6 +13,7 @@
 
 namespace I18nBundle\Model\RouteItem;
 
+use Pimcore\Model\DataObject\Data\UrlSlug;
 use Pimcore\Model\Element\ElementInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -51,4 +52,8 @@ interface BaseRouteItemInterface
     public function getRouteName(): ?string;
 
     public function setRouteName(?string $routeName): void;
+
+    public function getUrlSlug(): ?UrlSlug;
+
+    public function setUrlSlug(?UrlSlug $urlSlug): void;
 }

--- a/src/Model/RouteItem/RouteItemInterface.php
+++ b/src/Model/RouteItem/RouteItemInterface.php
@@ -18,4 +18,5 @@ interface RouteItemInterface extends BaseRouteItemInterface
     public const STATIC_ROUTE = 'static_route';
     public const SYMFONY_ROUTE = 'symfony';
     public const DOCUMENT_ROUTE = 'document';
+    public const DATA_OBJECT_ROUTE = 'data_object';
 }

--- a/src/Modifier/RouteModifier.php
+++ b/src/Modifier/RouteModifier.php
@@ -20,6 +20,7 @@ use I18nBundle\Exception\VirtualProxyPathException;
 use I18nBundle\LinkGenerator\I18nLinkGeneratorInterface;
 use I18nBundle\Manager\I18nContextManager;
 use I18nBundle\Model\RouteItem\RouteItemInterface;
+use I18nBundle\Model\SiteRequestContext;
 use I18nBundle\Model\ZoneInterface;
 use I18nBundle\Model\ZoneSiteInterface;
 use I18nBundle\Tool\System;
@@ -192,23 +193,53 @@ class RouteModifier
             return $documentPath;
         }
 
-        $scheme = $zoneSite->getSiteRequestContext()->getScheme();
-        $host = $zoneSite->getSiteRequestContext()->getHost();
-        $httpPort = $zoneSite->getSiteRequestContext()->getHttpPort();
-        $httpsPort = $zoneSite->getSiteRequestContext()->getHttpsPort();
+        return $this->generateAbsoluteUrl($zoneSite->getSiteRequestContext(), $documentPath);
+    }
 
-        $port = '';
-        if ($scheme === 'http' && $httpPort !== 80) {
-            $port = ':' . $httpPort;
-        } elseif ($scheme === 'https' && $httpsPort !== 443) {
-            $port = ':' . $httpsPort;
+    /**
+     * @throws \Exception
+     */
+    public function buildDataObjectPath(I18nContextInterface $i18nContext, int $referenceType): string
+    {
+        $routeItem = $i18nContext->getRouteItem();
+        $attributes = $routeItem->isHeadless()
+            ? $routeItem->getRouteParameters()
+            : $routeItem->getRouteAttributes();
+        $object = $routeItem->getEntity();
+        $urlSlug = $routeItem->getUrlSlug();
+
+        if (!$object instanceof Concrete) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Cannot build data object path. Entity must be an instance of "%s", "%s" given!',
+                    Concrete::class,
+                    get_class($object)
+                )
+            );
         }
 
-        if (!empty($documentPath)) {
-            $documentPath = '/' . ltrim($documentPath, '/');
+        $slugs = $object->get($urlSlug->getFieldname(), $attributes['_locale']);
+
+        if (empty($slugs)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'No slugs found in object field "%s" for locale "%s"',
+                    $urlSlug->getFieldname(),
+                    $attributes['_locale']
+                )
+            );
         }
 
-        return sprintf('%s://%s%s%s', $scheme, $host, $port, $documentPath);
+        $dataObjectPath = $slugs[0]->getSlug();
+
+        if ($referenceType !== UrlGeneratorInterface::ABSOLUTE_URL) {
+            return $dataObjectPath;
+        }
+
+        return $this->generateAbsoluteUrl(
+            $i18nContext->getCurrentZoneSite()->getSiteRequestContext(),
+            $dataObjectPath
+        );
     }
 
     protected function translateDynamicRouteKey(ZoneInterface $zone, RouteItemInterface $routeItem, string $key, string $locale): string
@@ -266,5 +297,26 @@ class RouteModifier
         }
 
         return $parameters;
+    }
+
+    private function generateAbsoluteUrl(SiteRequestContext $siteRequestContext, string $path): string
+    {
+        $scheme = $siteRequestContext->getScheme();
+        $host = $siteRequestContext->getHost();
+        $httpPort = $siteRequestContext->getHttpPort();
+        $httpsPort = $siteRequestContext->getHttpsPort();
+
+        $port = '';
+        if ($scheme === 'http' && $httpPort !== 80) {
+            $port = ':' . $httpPort;
+        } elseif ($scheme === 'https' && $httpsPort !== 443) {
+            $port = ':' . $httpsPort;
+        }
+
+        if (!empty($path)) {
+            $path = '/' . ltrim($path, '/');
+        }
+
+        return sprintf('%s://%s%s%s', $scheme, $host, $port, $path);
     }
 }

--- a/src/Routing/I18nRouter.php
+++ b/src/Routing/I18nRouter.php
@@ -107,6 +107,10 @@ class I18nRouter implements RouterInterface, RequestMatcherInterface, WarmableIn
             return $this->generateDocumentRoute($i18nContext, $referenceType);
         }
 
+        if ($i18nContext->getRouteItem()->getType() === RouteItemInterface::DATA_OBJECT_ROUTE) {
+            return $this->generateDataObjectRoute($i18nContext, $referenceType);
+        }
+
         throw new RouteNotFoundException(sprintf('None of the chained routers were able to generate i18n route: %s', $name));
     }
 
@@ -139,6 +143,11 @@ class I18nRouter implements RouterInterface, RequestMatcherInterface, WarmableIn
     protected function generateDocumentRoute(I18nContextInterface $i18nContext, int $referenceType): string
     {
         return $this->routeModifier->buildDocumentPath($i18nContext, $referenceType);
+    }
+
+    protected function generateDataObjectRoute(I18nContextInterface $i18nContext, int $referenceType): string
+    {
+        return $this->routeModifier->buildDataObjectPath($i18nContext, $referenceType);
     }
 
     protected function generateContextAwarePath(I18nContextInterface $i18nContext, RouteItemInterface $routeItem, int $referenceType): string

--- a/src/Transformer/AlternateRouteItemTransformer.php
+++ b/src/Transformer/AlternateRouteItemTransformer.php
@@ -39,6 +39,13 @@ class AlternateRouteItemTransformer implements TransformerInterface
         $alternateRouteItem->getRouteParametersBag()->set('_locale', $zoneSite->getLocale());
         $alternateRouteItem->getRouteContextBag()->set('site', $zoneSite->getPimcoreSite());
 
+        // Data object routes always have a route name, entity and url slug assigned
+        if ($routeItem->getType() === RouteItemInterface::DATA_OBJECT_ROUTE) {
+            $alternateRouteItem->setRouteName($routeItem->getRouteName());
+            $alternateRouteItem->setEntity($routeItem->getEntity());
+            $alternateRouteItem->setUrlSlug($routeItem->getUrlSlug());
+        }
+
         return $alternateRouteItem;
     }
 
@@ -66,7 +73,8 @@ class AlternateRouteItemTransformer implements TransformerInterface
                 'routeName'       => $transformedRouteItem->getRouteName(),
                 'routeParameters' => $transformedRouteItem->getRouteParameters(),
                 'routeAttributes' => $transformedRouteItem->getRouteAttributes(),
-                'context'         => $transformedRouteItem->getRouteContext()
+                'context'         => $transformedRouteItem->getRouteContext(),
+                'urlSlug'         => $transformedRouteItem->getUrlSlug(),
             ]
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR adds data object routes (Pimcore UrlSlugs) to the toolchain. It automatically generates alternate routes without the user's need to intervene.

@solverat I've opened the PR as draft, as I'm not quite sure if that's everything that needs to be done in order to cover the complete functionality the other route types already have. I'm glad if you could review and provide some feedback! I'll add documentation after the coding has been done... 😉