### PR TITLE
alternate route event: getter for current route item

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Notes
 
+## 5.1.1
+- [IMPROVEMENT] alternate route event: getter for current route item
 ## 5.1.0
 - [FEATURE] pimcore backend: object preview button
 - [IMPROVEMENT] prevent applying str_contains on null value

--- a/src/Event/AlternateDynamicRouteEvent.php
+++ b/src/Event/AlternateDynamicRouteEvent.php
@@ -39,6 +39,11 @@ class AlternateDynamicRouteEvent extends Event
         return $this->type;
     }
 
+    public function getCurrentRouteItem(): RouteItemInterface
+    {
+        return $this->currentRouteItem;
+    }
+
     public function isCurrentRouteHeadless(): bool
     {
         return $this->currentRouteItem->isHeadless() === true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR provides a getter for the current route item in `AlternateDynamicRouteEvent`
